### PR TITLE
Unify upload/download paths to project root directory

### DIFF
--- a/backend/app.py
+++ b/backend/app.py
@@ -419,7 +419,8 @@ class S3270Session:
             time.sleep(1.5)
 
         output_text = "\n\n".join(pages)
-        base_dir = os.path.dirname(os.path.abspath(__file__))
+        # Use project root directory for downloads (unified with Next.js uploads directory)
+        base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
         output_dir = os.path.join(base_dir, 'downloads', 'job_outputs')
         os.makedirs(output_dir, exist_ok=True)
 

--- a/data/functions.json
+++ b/data/functions.json
@@ -251,7 +251,7 @@
       },
       {
         "name": "Windows File Location",
-        "placeholder": "./uploads"
+        "placeholder": "uploads"
       },
       {
         "name": "Mainframe File Name",
@@ -274,7 +274,7 @@
       },
       {
         "name": "Windows File Location",
-        "placeholder": "./downloads"
+        "placeholder": "downloads"
       }
     ]
   },

--- a/src/services/functionExecutor.ts
+++ b/src/services/functionExecutor.ts
@@ -370,7 +370,7 @@ export class FunctionExecutor {
     try {
       // Extract parameters
       const windowsFileName = inputs['Windows File name'] || 'File1';
-      const windowsFileLocation = inputs['Windows File Location'] || './';
+      const windowsFileLocation = inputs['Windows File Location'] || 'uploads';
       const mainframeFileName = inputs['Mainframe File Name'] || 'SHIPRA.TEST.FILE2';
 
       // Construct full local path


### PR DESCRIPTION
- Modified backend/app.py to use project root for downloads directory
- Updated functions.json placeholders to use 'uploads' and 'downloads'
- Updated functionExecutor.ts default path to 'uploads'
- Created downloads directory in project root with job_outputs subdirectory

This ensures consistent file handling across npm run go (Next.js) and Python app.py